### PR TITLE
Remove `<style>` tag from style.css

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,4 +1,3 @@
-<style>
 	.header {
 		top: 0;
 	}
@@ -166,4 +165,3 @@
 		border: 1px solid black;
 		text-align: center;
 	}
-</style>


### PR DESCRIPTION
Since it's a CSS file rather than an HTML file, it doesn't need the `<style>` tag. I'm guessing browsers are tolerating the presence of the tag but it's technically a CSS parsing error.